### PR TITLE
Add WithConstant factory methods for single constant Setter creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Setters/issues/7
-Your prepared branch: issue-7-21c2ebc3
-Your prepared working directory: /tmp/gh-issue-solver-1757819122277
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Setters/issues/7
+Your prepared branch: issue-7-21c2ebc3
+Your prepared working directory: /tmp/gh-issue-solver-1757819122277
+
+Proceed.

--- a/csharp/Platform.Setters.Tests/SetterTests.cs
+++ b/csharp/Platform.Setters.Tests/SetterTests.cs
@@ -45,5 +45,31 @@ namespace Platform.Setters.Tests
             Assert.Equal(0, setter.SetFirstAndReturnFalse(new int[] { 4 }));
             Assert.Equal(4, setter.Result);
         }
+
+        [Fact]
+        public void WithConstantFactoryMethodTest()
+        {
+            Setter<int, int> setter = Setter<int, int>.WithConstant(42);
+            Assert.Equal(42, setter.TrueValue);
+            Assert.Equal(42, setter.FalseValue);
+            Assert.Equal(default, setter.Result);
+            Assert.Equal(42, setter.SetAndReturnTrue(1));
+            Assert.Equal(1, setter.Result);
+            Assert.Equal(42, setter.SetAndReturnFalse(2));
+            Assert.Equal(2, setter.Result);
+        }
+
+        [Fact]
+        public void WithConstantAndDefaultValueFactoryMethodTest()
+        {
+            Setter<int, int> setter = Setter<int, int>.WithConstant(42, 99);
+            Assert.Equal(42, setter.TrueValue);
+            Assert.Equal(42, setter.FalseValue);
+            Assert.Equal(99, setter.Result);
+            Assert.Equal(42, setter.SetAndReturnTrue(1));
+            Assert.Equal(1, setter.Result);
+            Assert.Equal(42, setter.SetAndReturnFalse(2));
+            Assert.Equal(2, setter.Result);
+        }
     }
 }

--- a/csharp/Platform.Setters/Setter[TResult, TDecision].cs
+++ b/csharp/Platform.Setters/Setter[TResult, TDecision].cs
@@ -88,6 +88,40 @@ namespace Platform.Setters
         public Setter() { }
         
         /// <summary>
+        /// <para>Creates a new instance of the <see cref="Setter{TResult, TDecision}"/> class using passed-in <paramref name="constantValue"/> as both true and false values.</para>
+        /// <para>Создает новый экземпляр класса <see cref="Setter{TResult, TDecision}"/>, используя переданное значение <paramref name="constantValue"/> в качестве значения для истины и лжи.</para>
+        /// </summary>
+        /// <param name="constantValue">
+        /// <para>A constant value that will be used for both true and false cases.</para>
+        /// <para>Константное значение, которое будет использоваться для случаев истины и лжи.</para>
+        /// </param>
+        /// <returns>
+        /// <para>A new instance of the <see cref="Setter{TResult, TDecision}"/> class with the same constant for both true and false values.</para>
+        /// <para>Новый экземпляр класса <see cref="Setter{TResult, TDecision}"/> с одинаковой константой для значений истины и лжи.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Setter<TResult, TDecision> WithConstant(TDecision constantValue) => new(constantValue, constantValue);
+        
+        /// <summary>
+        /// <para>Creates a new instance of the <see cref="Setter{TResult, TDecision}"/> class using passed-in <paramref name="constantValue"/> as both true and false values with the <paramref name="defaultValue"/> as a result.</para>
+        /// <para>Создает новый экземпляр класса <see cref="Setter{TResult, TDecision}"/>, используя переданное значение <paramref name="constantValue"/> в качестве значения для истины и лжи с <paramref name="defaultValue"/> в качестве результата.</para>
+        /// </summary>
+        /// <param name="constantValue">
+        /// <para>A constant value that will be used for both true and false cases.</para>
+        /// <para>Константное значение, которое будет использоваться для случаев истины и лжи.</para>
+        /// </param>
+        /// <param name="defaultValue">
+        /// <para>A default result value.</para>
+        /// <para>Результирующее значение по умолчанию.</para>
+        /// </param>
+        /// <returns>
+        /// <para>A new instance of the <see cref="Setter{TResult, TDecision}"/> class with the same constant for both true and false values and the specified default result value.</para>
+        /// <para>Новый экземпляр класса <see cref="Setter{TResult, TDecision}"/> с одинаковой константой для значений истины и лжи и указанным значением результата по умолчанию.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Setter<TResult, TDecision> WithConstant(TDecision constantValue, TResult defaultValue) => new(constantValue, constantValue, defaultValue);
+        
+        /// <summary>
         /// <para>Sets the <paramref name="value"/> to the <see cref="Result"/> and returns the value indicating true.</para>
         /// <para>Устанавливает <paramref name="value"/> в <see cref="Result"/> и возвращает значение обозначающее истину.</para>
         /// </summary>

--- a/experiments/SingleConstantSetterDemo.cs
+++ b/experiments/SingleConstantSetterDemo.cs
@@ -1,0 +1,41 @@
+using System;
+using Platform.Setters;
+
+namespace Platform.Setters.Experiments
+{
+    /// <summary>
+    /// Demo showing the usage of Setter with single constant as requested in issue #7.
+    /// This addresses the case where "in real life usage only one constant is actually used".
+    /// </summary>
+    class SingleConstantSetterDemo
+    {
+        static void Main()
+        {
+            // Example usage as requested in the issue: 
+            // "var setter = new Setter<uint, uint>(links.Constants.Break);"
+            
+            // Before: Required specifying both true/false values
+            Console.WriteLine("=== Before (traditional approach) ===");
+            var traditionalSetter = new Setter<uint, uint>(1, 0); // trueValue=1, falseValue=0
+            Console.WriteLine($"TrueValue: {traditionalSetter.TrueValue}, FalseValue: {traditionalSetter.FalseValue}");
+            
+            // After: Can use single constant for both true/false cases
+            Console.WriteLine("\n=== After (single constant approach) ===");
+            uint constantBreak = 42; // Simulating links.Constants.Break
+            var singleConstantSetter = Setter<uint, uint>.WithConstant(constantBreak);
+            Console.WriteLine($"TrueValue: {singleConstantSetter.TrueValue}, FalseValue: {singleConstantSetter.FalseValue}");
+            
+            // Both methods return the same constant value
+            Console.WriteLine("\n=== Testing functionality ===");
+            Console.WriteLine($"SetAndReturnTrue result: {singleConstantSetter.SetAndReturnTrue(100)}"); // Should return 42
+            Console.WriteLine($"SetAndReturnFalse result: {singleConstantSetter.SetAndReturnFalse(200)}"); // Should return 42
+            Console.WriteLine($"Final result value: {singleConstantSetter.Result}"); // Should be 200
+            
+            // Can also specify default value
+            Console.WriteLine("\n=== With default value ===");
+            var setterWithDefault = Setter<uint, uint>.WithConstant(constantBreak, 999);
+            Console.WriteLine($"TrueValue: {setterWithDefault.TrueValue}, FalseValue: {setterWithDefault.FalseValue}");
+            Console.WriteLine($"Initial result: {setterWithDefault.Result}"); // Should be 999
+        }
+    }
+}


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request solves issue #7 by implementing static factory methods that allow creating `Setter<TResult, TDecision>` instances with a single constant value.

### 📋 Issue Reference
Fixes #7 - Think about setter with single constant, without True/False cases

### 🔧 Implementation Details

#### Problem
The issue identified that "in real life usage only one constant is actually used," but the current API required specifying both true and false values:

```csharp
// Before: Required both true/false constants
var setter = new Setter<uint, uint>(constants.Continue, constants.Break, constants.Null);
```

#### Solution
Added two static factory methods to `Setter<TResult, TDecision>` class:

1. **`WithConstant(TDecision constantValue)`** - Creates a setter with the same constant for both true/false cases
2. **`WithConstant(TDecision constantValue, TResult defaultValue)`** - Same as above but with a specified default result value

#### Usage Examples

```csharp
// Simple single constant usage (as requested in the issue)
var setter = Setter<uint, uint>.WithConstant(links.Constants.Break);

// With default value
var setterWithDefault = Setter<uint, uint>.WithConstant(42, 999);

// Both methods return the same constant value
Console.WriteLine(setter.SetAndReturnTrue(100));  // Returns: 42
Console.WriteLine(setter.SetAndReturnFalse(200)); // Returns: 42
```

### ✅ Changes Made

- **Added static factory methods**: `WithConstant(constantValue)` and `WithConstant(constantValue, defaultValue)`
- **Comprehensive tests**: Added `WithConstantFactoryMethodTest` and `WithConstantAndDefaultValueFactoryMethodTest` 
- **Demo implementation**: Created `experiments/SingleConstantSetterDemo.cs` showing real-world usage
- **Constructor disambiguation**: Used static factory pattern to avoid ambiguity issues when `TResult` and `TDecision` are the same type

### 🧪 Testing

All tests pass (6/6):
- Existing functionality remains unchanged
- New factory methods work correctly with same constant for both true/false values
- Both variants (with and without default value) function as expected

### 📚 Design Rationale

**Why static factory methods instead of constructors?**
- Avoids constructor ambiguity when `TResult` and `TDecision` are the same type (e.g., `Setter<uint, uint>`)
- Provides clear, descriptive names that indicate the behavior
- Follows established patterns in the .NET ecosystem
- Maintains backward compatibility

The implementation addresses the core need expressed in the issue while maintaining clean, unambiguous API design.

---
🤖 Generated with [Claude Code](https://claude.ai/code)